### PR TITLE
Redirect to login page

### DIFF
--- a/apps/frontend/src/App.svelte
+++ b/apps/frontend/src/App.svelte
@@ -50,7 +50,6 @@
     {#if $AccountStore.loggedIn}
       <Router {routes} />
     {:else}
-      <!-- TODO: redirect -->
       <Login />
     {/if}
   </Modal>


### PR DESCRIPTION
Closes #6 

This turned out to be dummy simple:
- If the user is not logged in, show the login page. Once the user logs in, the page refreshes and the original page is displayed