### PR TITLE
Clean up the changing NFT default contract and added admin commands and have generic NFT send

### DIFF
--- a/apps/bot/src/commands/AddAdmins.ts
+++ b/apps/bot/src/commands/AddAdmins.ts
@@ -13,13 +13,13 @@ import {
 import { createDiscordErrMsg, parseDiscordRecipient } from '@baf-wallet/utils';
 import { constants } from '../config/config';
 
-export default class setDefaultNFT extends Command {
+export default class AddAdmins extends Command {
   constructor(protected client: BotClient) {
     super(client, {
-      name: 'setDefaultNFT',
-      description: 'Set the default NFT contract for this Discord',
+      name: 'addAdmins',
+      description: 'Add admin Near Accounts to the contract',
       category: 'Utility',
-      usage: `${client.settings.prefix}setDefaultNFT [NFT Contract]`,
+      usage: `${client.settings.prefix}addAdmins adminAccount1, adminAccount2, adminAccount3...`,
       cooldown: 1000,
       requiredPermissions: [],
     });
@@ -27,15 +27,15 @@ export default class setDefaultNFT extends Command {
 
   private buildGenericTx(
     contractAddress: string,
-    nftContractAddress: string
+    new_admins: string[]
   ): GenericTxParams {
     let actions: GenericTxAction[];
     actions = [
       {
         type: GenericTxSupportedActions.CONTRACT_CALL,
-        functionName: 'set_default_nft_contract',
+        functionName: 'add_admins',
         functionArgs: {
-          nft_contract: nftContractAddress,
+          new_admins,
         },
         deposit: '0',
       },
@@ -52,7 +52,7 @@ export default class setDefaultNFT extends Command {
   }
 
   private extractArgs(content: string): string[] | null {
-    const rx = /^\%setDefaultNFT (.*)$/g;
+    const rx = /^\%addAdmins (.*)$/g;
     const matched = rx.exec(content);
     if (!matched) return null;
     // The first element of the match is the whole string if it matched
@@ -82,12 +82,12 @@ export default class setDefaultNFT extends Command {
       return;
     }
 
-    const defaultNFTContract = args[0];
+    const admins = args[0].split(', ');
 
     try {
       const tx = await this.buildGenericTx(
         constants.communityContractAddr,
-        defaultNFTContract
+        admins
       );
       if (!tx) return;
       const link = createApproveRedirectURL(
@@ -101,7 +101,7 @@ export default class setDefaultNFT extends Command {
         "Please check your DM's for a link to approve the transaction!"
       );
       await message.author.send(
-        `To open BAF Wallet and approve changing the default NFT contract to ${defaultNFTContract}, please open this link: ${link}`
+        `To open BAF Wallet and add ${JSON.stringify(admins)} as admins, please open this link: ${link}`
       );
     } catch (err) {
       console.error(err);

--- a/apps/bot/src/commands/RemoveAdmins.ts
+++ b/apps/bot/src/commands/RemoveAdmins.ts
@@ -13,13 +13,13 @@ import {
 import { createDiscordErrMsg, parseDiscordRecipient } from '@baf-wallet/utils';
 import { constants } from '../config/config';
 
-export default class setDefaultNFT extends Command {
+export default class RemoveAdmins extends Command {
   constructor(protected client: BotClient) {
     super(client, {
-      name: 'setDefaultNFT',
-      description: 'Set the default NFT contract for this Discord',
+      name: 'removeAdmins',
+      description: 'Remove admin Near Accounts from the contract',
       category: 'Utility',
-      usage: `${client.settings.prefix}setDefaultNFT [NFT Contract]`,
+      usage: `${client.settings.prefix}removeAdmins adminAccount1, adminAccount2, adminAccount3...`,
       cooldown: 1000,
       requiredPermissions: [],
     });
@@ -27,15 +27,15 @@ export default class setDefaultNFT extends Command {
 
   private buildGenericTx(
     contractAddress: string,
-    nftContractAddress: string
+    admins: string[]
   ): GenericTxParams {
     let actions: GenericTxAction[];
     actions = [
       {
         type: GenericTxSupportedActions.CONTRACT_CALL,
-        functionName: 'set_default_nft_contract',
+        functionName: 'remove_admins',
         functionArgs: {
-          nft_contract: nftContractAddress,
+          admins,
         },
         deposit: '0',
       },
@@ -52,7 +52,7 @@ export default class setDefaultNFT extends Command {
   }
 
   private extractArgs(content: string): string[] | null {
-    const rx = /^\%setDefaultNFT (.*)$/g;
+    const rx = /^\%removeAdmins (.*)$/g;
     const matched = rx.exec(content);
     if (!matched) return null;
     // The first element of the match is the whole string if it matched
@@ -82,12 +82,12 @@ export default class setDefaultNFT extends Command {
       return;
     }
 
-    const defaultNFTContract = args[0];
+    const admins = args[0].split(', ');
 
     try {
       const tx = await this.buildGenericTx(
         constants.communityContractAddr,
-        defaultNFTContract
+        admins
       );
       if (!tx) return;
       const link = createApproveRedirectURL(
@@ -101,7 +101,7 @@ export default class setDefaultNFT extends Command {
         "Please check your DM's for a link to approve the transaction!"
       );
       await message.author.send(
-        `To open BAF Wallet and approve changing the default NFT contract to ${defaultNFTContract}, please open this link: ${link}`
+        `To open BAF Wallet and remove ${JSON.stringify(admins)} as admins, please open this link: ${link}`
       );
     } catch (err) {
       console.error(err);

--- a/apps/bot/src/commands/index.ts
+++ b/apps/bot/src/commands/index.ts
@@ -3,4 +3,7 @@ import Send from './Send';
 import SendNFT from './SendNFT';
 import InitAccount from './InitAccount';
 import setDefaultNFT from './SetDefaultNFT';
-export default [Ping, Send, SendNFT, InitAccount, setDefaultNFT];
+import AddAdmins from './AddAdmins';
+import RemoveAdmins from './RemoveAdmins';
+
+export default [Ping, Send, SendNFT, InitAccount, setDefaultNFT, AddAdmins, RemoveAdmins];

--- a/apps/bot/src/config/config.ts
+++ b/apps/bot/src/config/config.ts
@@ -24,4 +24,6 @@ export const constants = {
       masterAccountID: process.env.NEAR_MASTER_ACCOUNT_ID,
     } as NearInitParams,
   },
+  communityContractAddr: require('../../../../libs/community-contract/config.json')
+    .contractName,
 };

--- a/apps/bot/src/main.ts
+++ b/apps/bot/src/main.ts
@@ -2,14 +2,17 @@ import 'reflect-metadata';
 import { environment } from './environments/environment';
 import { Container } from 'typedi';
 import { Client } from './Client';
-import { initChains } from '@baf-wallet/global-state';
+import { getNearChain, initChains } from '@baf-wallet/global-state';
 import { constants } from './config/config';
+import { setCommunityContract } from '@baf-wallet/community-contract';
+import { getWrappedInterface } from '@baf-wallet/multi-chain';
 
 // Initialize the Client using the IoC.
 const client = Container.get<Client>(Client);
 
 async function main() {
   await initChains(constants.chainParams);
+  await setCommunityContract(await getNearChain().getInner().nearMasterAccount);
   await client.login(environment.DISCORD_BOT_TOKEN);
   console.log('tokenbot happily hodling along');
 }

--- a/libs/community-contract/src/lib/community-contract.ts
+++ b/libs/community-contract/src/lib/community-contract.ts
@@ -24,6 +24,7 @@ interface CommunityContract {
     user_id: string,
     secp_sig_s: RustEncodedSecpSig
   ) => Promise<void>;
+  get_default_nft_contract: () => Promise<string>;
 }
 
 let communityContract: CommunityContract;
@@ -60,7 +61,7 @@ async function buildCommunityContract(
   });
 
   return {
-    ...contract,
+    ...(contract as any),
     /**
      * Below are override functions for the calls
      * Find the contract code in libs/community-contract/contract

--- a/libs/near/src/lib/tx.ts
+++ b/libs/near/src/lib/tx.ts
@@ -136,7 +136,7 @@ function buildNativeAction(
           paramsContractCall.functionName,
           paramsContractCall.functionArgs,
           new BN(10000000000000), // Maximum gas fee
-          new BN(0)
+          new BN(paramsContractCall.deposit || 0)
         ),
       ];
     default:


### PR DESCRIPTION
- Added commands to set admins
- Cleaned up NFT Default Contract Code
- Allow for sending NFTs using the default contract as well as a specified one

Closes #23, #24, and #16 